### PR TITLE
Enforce borders

### DIFF
--- a/src/renderer/components/DependsOnView.tsx
+++ b/src/renderer/components/DependsOnView.tsx
@@ -56,6 +56,7 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
     const container = d3.select('.depends-wrapper');
     const width = parseInt(container.style('width'), 10);
     const height = parseInt(container.style('height'), 10);
+    const radius = 60;
 
     //initialize graph
     const forceGraph = d3
@@ -66,14 +67,23 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
 
     //set location when ticked
     const ticked = () => {
+      textsAndNodes
+        .attr('cx', (d: any) => {
+          return (d.x = Math.max(radius, Math.min(width - radius, d.x)));
+        })
+        .attr('cy', (d: any) => {
+          return (d.y = Math.max(radius, Math.min(height - radius, d.y)));
+        })
+        .attr('transform', (d: any) => {
+          return 'translate(' + d.x + ',' + d.y + ')';
+        });
+
       link
         .attr('x1', (d: any) => d.source.x)
         .attr('y1', (d: any) => d.source.y)
         .attr('x2', (d: any) => d.target.x)
         .attr('y2', (d: any) => d.target.y);
-      textsAndNodes.attr('transform', (d: any) => {
-        return 'translate(' + d.x + ',' + d.y + ')';
-      });
+
     };
 
     //create force simulation
@@ -89,6 +99,7 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
       .force('charge', d3.forceManyBody<SNode>().strength(-400))
       .force('center', d3.forceCenter<SNode>(width / 2, height / 2))
       .on('tick', ticked);
+    // .on('tick', tickActions);
 
     //create Links
     const link = forceGraph

--- a/src/renderer/components/DependsOnView.tsx
+++ b/src/renderer/components/DependsOnView.tsx
@@ -79,11 +79,10 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
         });
 
       link
-        .attr('x1', (d: any) => d.source.x)
-        .attr('y1', (d: any) => d.source.y)
-        .attr('x2', (d: any) => d.target.x)
-        .attr('y2', (d: any) => d.target.y);
-
+        .attr('x1', (d: any) => d.source.x + 30)
+        .attr('y1', (d: any) => d.source.y + 30)
+        .attr('x2', (d: any) => d.target.x + 30)
+        .attr('y2', (d: any) => d.target.y + 30);
     };
 
     //create force simulation
@@ -99,7 +98,6 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
       .force('charge', d3.forceManyBody<SNode>().strength(-400))
       .force('center', d3.forceCenter<SNode>(width / 2, height / 2))
       .on('tick', ticked);
-    // .on('tick', tickActions);
 
     //create Links
     const link = forceGraph

--- a/src/renderer/components/DependsOnView.tsx
+++ b/src/renderer/components/DependsOnView.tsx
@@ -56,7 +56,7 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
     const container = d3.select('.depends-wrapper');
     const width = parseInt(container.style('width'), 10);
     const height = parseInt(container.style('height'), 10);
-    const radius = 60;
+    const radius = 60;  // Used to determine the size of each container for border enforcement
 
     //initialize graph
     const forceGraph = d3
@@ -67,6 +67,7 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
 
     //set location when ticked
     const ticked = () => {
+      // Enforces borders
       textsAndNodes
         .attr('cx', (d: any) => {
           return (d.x = Math.max(radius, Math.min(width - radius, d.x)));
@@ -77,7 +78,7 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
         .attr('transform', (d: any) => {
           return 'translate(' + d.x + ',' + d.y + ')';
         });
-
+        
       link
         .attr('x1', (d: any) => d.source.x + 30)
         .attr('y1', (d: any) => d.source.y + 30)


### PR DESCRIPTION
Added a radius variable to mimic the size of each container (set to 60) could be dynamic if we find a need.

Changed the tick function to limit the x and y values for each container to (the size of the svg element) - (the size of the radius).

Also, moved the end points for each line behind the line's respective container position.  Now the lines are no longer connected at a position outside of the position of the containers.