### PR TITLE
Fixed bug that wouldn't allow containers to touch top and left border

### DIFF
--- a/src/renderer/components/DependsOnView.tsx
+++ b/src/renderer/components/DependsOnView.tsx
@@ -62,7 +62,9 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
     const forceGraph = d3
       .select('.depends-wrapper')
       .append('svg')
-      .attr('class', 'graph');
+      .attr('class', 'graph')
+      .attr('width', width)
+      .attr('height', height);
 
     //set location when ticked
     const ticked = () => {
@@ -99,13 +101,7 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
       .force('center', d3.forceCenter<SNode>(width / 2, height / 2))
       .on('tick', ticked);
 
-    const svg = d3
-      .select('.depends-wrapper')
-      .append('svg')
-      .attr('width', width)
-      .attr('height', height);
-
-    svg
+    forceGraph
       .append('svg:defs')
       .selectAll('marker')
       .data(['end']) // Different link/path types can be defined here
@@ -169,9 +165,6 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
         setSelectedContainer(node.name);
       })
       .call(drag);
-
-    // create texts
-    textsAndNodes.append('text').text((d: any) => d.name);
 
     //create container images
     textsAndNodes

--- a/src/renderer/components/DependsOnView.tsx
+++ b/src/renderer/components/DependsOnView.tsx
@@ -52,6 +52,7 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
     links,
   };
 
+  
   useEffect(() => {
     const container = d3.select('.depends-wrapper');
     const width = parseInt(container.style('width'), 10);
@@ -60,11 +61,11 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
 
     //initialize graph
     const forceGraph = d3
-      .select('.depends-wrapper')
-      .append('svg')
-      .attr('class', 'graph')
-      .attr('width', width)
-      .attr('height', height);
+    .select('.depends-wrapper')
+    .append('svg')
+    .attr('class', 'graph')
+    .attr('width', width)
+    .attr('height', height);
 
     //set location when ticked
     const ticked = () => {
@@ -165,6 +166,9 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
         setSelectedContainer(node.name);
       })
       .call(drag);
+
+    // create texts
+    textsAndNodes.append('text').text((d: any) => d.name);
 
     //create container images
     textsAndNodes

--- a/src/renderer/components/DependsOnView.tsx
+++ b/src/renderer/components/DependsOnView.tsx
@@ -70,10 +70,10 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
       // Enforces borders
       textsAndNodes
         .attr('cx', (d: any) => {
-          return (d.x = Math.max(radius, Math.min(width - radius, d.x)));
+          return (d.x = Math.max(0, Math.min(width - radius, d.x)));
         })
         .attr('cy', (d: any) => {
-          return (d.y = Math.max(radius, Math.min(height - radius, d.y)));
+          return (d.y = Math.max(15, Math.min(height - radius, d.y)));
         })
         .attr('transform', (d: any) => {
           return 'translate(' + d.x + ',' + d.y + ')';

--- a/src/renderer/components/DependsOnView.tsx
+++ b/src/renderer/components/DependsOnView.tsx
@@ -51,7 +51,6 @@ const DependsOnView: React.FC<Props> = ({ services, setSelectedContainer }) => {
     nodes,
     links,
   };
-
   
   useEffect(() => {
     const container = d3.select('.depends-wrapper');

--- a/src/renderer/helpers/yamlParser.ts
+++ b/src/renderer/helpers/yamlParser.ts
@@ -12,7 +12,7 @@ type YamlState = {
 export const convertYamlToState = (file: any) => {
   const services = file.services;
   const volumes = file.volumes ? file.volumes : {};
-  const networks = file.networks ? file.volumes : {};
+  const networks = file.networks ? file.networks : {};
   const state: YamlState = Object.assign(
     {},
     { fileUploaded: true, services, volumes, networks },

--- a/src/renderer/styles/d3Wrapper.scss
+++ b/src/renderer/styles/d3Wrapper.scss
@@ -2,6 +2,8 @@
   display: flex;
   flex: 1 1 0;
   min-height: 500px;
+  align-items: center;
+  justify-content: center;
 
   .services-wrapper {
     flex: 1 1 0;
@@ -46,8 +48,13 @@
     }
   }
 
+  .file-upload {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
   div button {
-    display: block;
     margin: 0 auto;
   }
 }


### PR DESCRIPTION
Fixed the bug that wouldn't allow containers to touch the top and left borders of the svg canvas.

Still have to decide how we want to deal with container text overflowing the right border of the svg.  
It currently disappears behind the right edge, not necessarily a problem.  But we might want to look into enforcing a text border.