### PR TITLE
Created d3 global variables

### DIFF
--- a/src/renderer/App.d.ts
+++ b/src/renderer/App.d.ts
@@ -15,6 +15,28 @@ export type State = {
   version: string;
 };
 
+interface SNode extends SimulationNodeDatum {
+  id: number;
+  name: string;
+  ports: string[];
+  volumes: string[];
+  networks?: string[];
+  row: number;
+  column: number;
+  rowLength: number;
+  children: NodeChild;
+}
+
+interface Link extends SimulationLinkDatum<SNode> {
+  source: string;
+  target: string;
+}
+
+type SGraph = {
+  nodes: SNode[];
+  links: Link[];
+};
+
 type ViewT = 'networks' | 'depends_on';
 
 type Clicked = {
@@ -36,28 +58,6 @@ export type Options = {
 
 export type NodeChild = {
   [service: string]: SNode;
-};
-
-interface SNode extends SimulationNodeDatum {
-  id: number;
-  name: string;
-  ports: string[];
-  volumes: string[];
-  networks?: string[];
-  row: number;
-  column: number;
-  rowLength: number;
-  children: NodeChild;
-}
-
-interface Link extends SimulationLinkDatum<SNode> {
-  source: string;
-  target: string;
-}
-
-type SGraph = {
-  nodes: SNode[];
-  links: Link[];
 };
 
 export type Service = {

--- a/src/renderer/App.d.ts
+++ b/src/renderer/App.d.ts
@@ -48,7 +48,6 @@ interface SNode extends SimulationNodeDatum {
   column: number;
   rowLength: number;
   children: NodeChild;
-  networks?: string[];
 }
 
 interface Link extends SimulationLinkDatum<SNode> {
@@ -103,3 +102,5 @@ export type TreeMap = {
 export type Networks = {
   [network: string]: any;
 };
+
+export type Simulation = d3.Simulation<SNode, undefined>;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import { ipcRenderer } from 'electron';
 
 //IMPORT HELPER FUNCTIONS
 import { convertYamlToState } from './helpers/yamlParser';
+import setGlobalVars from './helpers/setGlobalVars';
 
 // IMPORT STYLES
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -90,6 +91,7 @@ class App extends Component<{}, State> {
   convertAndStoreYamlJSON = (yamlText: string) => {
     const yamlJSON = yaml.safeLoad(yamlText);
     const yamlState = convertYamlToState(yamlJSON);
+    setGlobalVars(yamlState.services);
     localStorage.setItem('state', JSON.stringify(yamlState));
     this.setState(Object.assign(initialState, yamlState));
   };
@@ -111,6 +113,7 @@ class App extends Component<{}, State> {
     const stateJSON = localStorage.getItem('state');
     if (stateJSON) {
       const stateJS = JSON.parse(stateJSON);
+      setGlobalVars(stateJS.services);
       this.setState(Object.assign(initialState, stateJS));
     }
   }

--- a/src/renderer/components/Links.tsx
+++ b/src/renderer/components/Links.tsx
@@ -11,17 +11,19 @@
 import React, { useEffect } from 'react';
 import * as d3 from 'd3';
 // IMPORT HELPER FUNCTIONS
-import { Link, Services, Options, Simulation, SNode } from '../App.d';
+import { Link, Services, Options, SNode } from '../App.d';
 // IMPORT TYPES
 
 type Props = {
-  links: Link[];
   services: Services;
   options: Options;
-  simulation: Simulation;
 };
 
-const Links: React.FC<Props> = ({ links, services, options, simulation }) => {
+const Links: React.FC<Props> = ({ services, options }) => {
+  const {
+    simulation,
+    serviceGraph: { links },
+  } = window;
   useEffect(() => {
     simulation.force(
       'link',

--- a/src/renderer/components/Links.tsx
+++ b/src/renderer/components/Links.tsx
@@ -11,17 +11,26 @@
 import React, { useEffect } from 'react';
 import * as d3 from 'd3';
 // IMPORT HELPER FUNCTIONS
-import { Link, Services, Options } from '../App.d';
+import { Link, Services, Options, Simulation, SNode } from '../App.d';
 // IMPORT TYPES
 
 type Props = {
   links: Link[];
   services: Services;
   options: Options;
+  simulation: Simulation;
 };
 
-const Links: React.FC<Props> = ({ links, services, options }) => {
+const Links: React.FC<Props> = ({ links, services, options, simulation }) => {
   useEffect(() => {
+    simulation.force(
+      'link',
+      d3
+        .forceLink<SNode, Link>(links)
+        .distance(130)
+        .id((node: SNode) => node.name),
+    );
+
     //initialize graph
     const forceGraph = d3.select('.graph');
 

--- a/src/renderer/components/Nodes.tsx
+++ b/src/renderer/components/Nodes.tsx
@@ -17,31 +17,19 @@ import {
 } from '../helpers/getSimulationDimensions';
 import { getStatic } from '../helpers/static';
 // IMPORT TYPES
-import {
-  SNode,
-  SetSelectedContainer,
-  Services,
-  Options,
-  Simulation,
-} from '../App.d';
+import { SNode, SetSelectedContainer, Services, Options } from '../App.d';
 // IMPORT COMPONENTS
 import NodePorts from './NodePorts';
 import NodeVolumes from './NodeVolumes';
 
 type Props = {
   services: Services;
-  nodes: SNode[];
   setSelectedContainer: SetSelectedContainer;
-  simulation: Simulation;
-  treeDepth: number;
   options: Options;
 };
 
 const Nodes: React.FC<Props> = ({
-  nodes,
   setSelectedContainer,
-  simulation,
-  treeDepth,
   services,
   options,
 }) => {
@@ -57,7 +45,7 @@ const Nodes: React.FC<Props> = ({
 
     //sets 'clicked' nodes back to unfixed position
     const dblClick = (d: SNode) => {
-      simulation.alphaTarget(0);
+      window.simulation.alphaTarget(0);
       d.fx = null;
       d.fy = null;
     };
@@ -65,7 +53,7 @@ const Nodes: React.FC<Props> = ({
     let drag = d3
       .drag<SVGGElement, SNode>()
       .on('start', function dragstarted(d: SNode) {
-        if (!d3.event.active) simulation.alphaTarget(0.3).restart();
+        if (!d3.event.active) window.simulation.alphaTarget(0.3).restart();
         d.fx = d3.event.x;
         d3.event.y;
       })
@@ -75,7 +63,7 @@ const Nodes: React.FC<Props> = ({
         d.fy = d3.event.y;
       })
       .on('end', function dragended(d: SNode) {
-        if (!d3.event.active) simulation.alphaTarget(0);
+        if (!d3.event.active) window.simulation.alphaTarget(0);
         d.fx = d.x;
         d.fy = d.y;
       });
@@ -84,7 +72,7 @@ const Nodes: React.FC<Props> = ({
     const nodeContainers = d3
       .select('.nodes')
       .selectAll('g')
-      .data<SNode>(nodes)
+      .data<SNode>(window.serviceGraph.nodes)
       .enter()
       .append('g')
       .on('click', (node: SNode) => {
@@ -97,7 +85,7 @@ const Nodes: React.FC<Props> = ({
         return (d.fx = getHorizontalPosition(d, width));
       })
       .attr('fy', (d: SNode) => {
-        return (d.fy = getVerticalPosition(d, treeDepth, height));
+        return (d.fy = getVerticalPosition(d, window.treeDepth, height));
       });
 
     // add names of services

--- a/src/renderer/components/Nodes.tsx
+++ b/src/renderer/components/Nodes.tsx
@@ -17,7 +17,13 @@ import {
 } from '../helpers/getSimulationDimensions';
 import { getStatic } from '../helpers/static';
 // IMPORT TYPES
-import { SNode, SetSelectedContainer, Services, Options } from '../App.d';
+import {
+  SNode,
+  SetSelectedContainer,
+  Services,
+  Options,
+  Simulation,
+} from '../App.d';
 // IMPORT COMPONENTS
 import NodePorts from './NodePorts';
 import NodeVolumes from './NodeVolumes';
@@ -26,7 +32,7 @@ type Props = {
   services: Services;
   nodes: SNode[];
   setSelectedContainer: SetSelectedContainer;
-  simulation: d3.Simulation<SNode, undefined>;
+  simulation: Simulation;
   treeDepth: number;
   options: Options;
 };

--- a/src/renderer/components/View.tsx
+++ b/src/renderer/components/View.tsx
@@ -263,21 +263,6 @@ const DependsOnView: React.FC<Props> = ({
     window.addEventListener('resize', ticked);
   }, [view]);
 
-  /**
-   *********************
-   * DEPENDS ON OPTION TOGGLE
-   *********************
-   */
-  useEffect(() => {
-    if (options.dependsOn) {
-      d3.select('.arrowsGroup').classed('hide', false);
-      d3.select('.links').classed('hide', false);
-    } else {
-      d3.select('.arrowsGroup').classed('hide', true);
-      d3.select('.links').classed('hide', true);
-    }
-  }, [options.dependsOn]);
-
   return (
     <>
       <div className="depends-wrapper">

--- a/src/renderer/components/View.tsx
+++ b/src/renderer/components/View.tsx
@@ -144,13 +144,7 @@ const DependsOnView: React.FC<Props> = ({
     links,
   };
 
-  const simulation = d3.forceSimulation<SNode>(serviceGraph.nodes).force(
-    'link',
-    d3
-      .forceLink<SNode, Link>(serviceGraph.links)
-      .distance(130)
-      .id((node: SNode) => node.name),
-  );
+  window.simulation = d3.forceSimulation<SNode>(serviceGraph.nodes);
 
   /**
    *********************
@@ -201,7 +195,10 @@ const DependsOnView: React.FC<Props> = ({
     }
 
     if (view === 'depends_on') {
-      simulation.force('charge', d3.forceManyBody<SNode>().strength(-400));
+      window.simulation.force(
+        'charge',
+        d3.forceManyBody<SNode>().strength(-400),
+      );
       d3Nodes
         .attr('fx', (d: any) => {
           //assign the initial x location to the relative displacement from the left
@@ -210,7 +207,7 @@ const DependsOnView: React.FC<Props> = ({
         .attr('fy', (d: any) => {
           return (d.fy = getVerticalPosition(d, treeDepth, height));
         });
-      simulation.on('tick', ticked);
+      window.simulation.on('tick', ticked);
     } else {
       d3Nodes
         .attr('fx', (d: any) => {
@@ -254,7 +251,7 @@ const DependsOnView: React.FC<Props> = ({
 
       const forceY = d3.forceY(height / 2).strength(0.5);
       //create force simulation
-      simulation
+      window.simulation
         .force('x', forceX)
         .force('y', forceY)
         .force('charge', d3.forceManyBody<SNode>().strength(-radius * 3))
@@ -286,7 +283,7 @@ const DependsOnView: React.FC<Props> = ({
       <div className="depends-wrapper">
         <svg className="graph">
           <Nodes
-            simulation={simulation}
+            simulation={window.simulation}
             treeDepth={treeDepth}
             nodes={serviceGraph.nodes}
             setSelectedContainer={setSelectedContainer}
@@ -294,6 +291,7 @@ const DependsOnView: React.FC<Props> = ({
             options={options}
           />
           <Links
+            simulation={window.simulation}
             links={serviceGraph.links}
             services={services}
             options={options}

--- a/src/renderer/components/View.tsx
+++ b/src/renderer/components/View.tsx
@@ -151,9 +151,9 @@ const DependsOnView: React.FC<Props> = ({
           }
           return width / 2;
         })
-        .strength(0.5);
+        .strength(1);
 
-      const forceY = d3.forceY(height / 2).strength(0.5);
+      const forceY = d3.forceY(height / 2).strength(1);
       //create force simulation
       window.simulation
         .force('x', forceX)

--- a/src/renderer/helpers/setGlobalVars.ts
+++ b/src/renderer/helpers/setGlobalVars.ts
@@ -122,7 +122,6 @@ const setGlobalVars: SetGlobalVars = services => {
     nodes,
     links,
   };
-
   window.simulation = d3.forceSimulation<SNode>(window.serviceGraph.nodes);
 };
 

--- a/src/renderer/helpers/setGlobalVars.ts
+++ b/src/renderer/helpers/setGlobalVars.ts
@@ -1,0 +1,129 @@
+/**
+ * ************************************
+ *
+ * @module  setGlobalVars.ts
+ * @author
+ * @date 3/24/20
+ * @description algorithm to set global vars for forcegraph simulation
+ *
+ * ************************************
+ */
+import {
+  Services,
+  NodesObject,
+  TreeMap,
+  NodeChild,
+  Link,
+  SNode,
+} from '../App.d';
+import * as d3 from 'd3';
+
+interface SetGlobalVars {
+  (services: Services): void;
+}
+
+const setGlobalVars: SetGlobalVars = services => {
+  let links: Link[] = [];
+  const nodesObject: NodesObject = Object.keys(services).reduce(
+    (acc: NodesObject, sName: string, i) => {
+      const ports: string[] = [];
+      const volumes: string[] = [];
+      const networks: string[] = [];
+      if (services[sName].hasOwnProperty('ports')) {
+        services[sName].ports.forEach(port => {
+          ports.push(port);
+        });
+      }
+      if (services[sName].hasOwnProperty('volumes')) {
+        services[sName].volumes.forEach(vol => {
+          volumes.push(vol);
+        });
+      }
+      if (services[sName].hasOwnProperty('depends_on')) {
+        services[sName].depends_on.forEach(el => {
+          links.push({ source: el, target: sName });
+        });
+      }
+      if (services[sName].hasOwnProperty('networks')) {
+        services[sName].networks.forEach(net => {
+          networks.push(net);
+        });
+      }
+      const node = {
+        id: i,
+        name: sName,
+        ports,
+        volumes,
+        networks,
+        children: {},
+        row: 0,
+        rowLength: 0,
+        column: 0,
+      };
+      acc[sName] = node;
+      return acc;
+    },
+    {},
+  );
+
+  //roots object creation, needs to be a deep copy or else deletion of non-roots will remove from nodesObject
+  const roots = JSON.parse(JSON.stringify(nodesObject));
+  //iterate through links and find if the roots object contains any of the link targets
+  links.forEach((link: Link) => {
+    if (roots[link.target]) {
+      //filter the roots
+      delete roots[link.target];
+    }
+  });
+
+  //create Tree
+  const createTree = (node: NodeChild) => {
+    Object.keys(node).forEach((root: string) => {
+      links.forEach((link: Link) => {
+        if (link.source === root) {
+          node[root].children[link.target] = nodesObject[link.target];
+        }
+      });
+      createTree(node[root].children);
+    });
+  };
+  createTree(roots);
+
+  //traverse tree and create object outlining the rows/columns in each tree
+  const treeMap: TreeMap = {};
+  const createTreeMap = (node: NodeChild, height: number = 0) => {
+    if (!treeMap[height] && Object.keys(node).length > 0) treeMap[height] = [];
+    Object.keys(node).forEach((sName: string) => {
+      treeMap[height].push(sName);
+      createTreeMap(node[sName].children, height + 1);
+    });
+  };
+  createTreeMap(roots);
+
+  // populate nodesObject with column, row, and rowLength
+  const storePositionLocation = (treeHierarchy: TreeMap) => {
+    Object.keys(treeHierarchy).forEach((row: string) => {
+      treeHierarchy[row].forEach((sName: string, column: number) => {
+        nodesObject[sName].row = Number(row);
+        if (!nodesObject[sName].column) nodesObject[sName].column = column + 1;
+        nodesObject[sName].rowLength = treeHierarchy[row].length;
+      });
+    });
+  };
+  storePositionLocation(treeMap);
+  /**
+   *********************
+   * Variables for d3 visualizer
+   *********************
+   */
+  window.treeDepth = Object.keys(treeMap).length;
+  const nodes = Object.values(nodesObject);
+  window.serviceGraph = {
+    nodes,
+    links,
+  };
+
+  window.simulation = d3.forceSimulation<SNode>(window.serviceGraph.nodes);
+};
+
+export default setGlobalVars;

--- a/src/renderer/helpers/yamlParser.ts
+++ b/src/renderer/helpers/yamlParser.ts
@@ -1,8 +1,8 @@
-import { ReadOnlyObj, DependsOn } from '../App.d';
+import { ReadOnlyObj, DependsOn, Services } from '../App.d';
 
 type YamlState = {
   fileUploaded: boolean;
-  services?: ReadOnlyObj;
+  services: Services;
   dependsOn?: DependsOn;
   networks?: ReadOnlyObj;
   volumes?: Array<ReadOnlyObj>;

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -12,7 +12,7 @@
 import * as React from 'react';
 import { render } from 'react-dom';
 import App from './App';
-import { Simulation } from '../renderer/App.d';
+import { Simulation, SGraph } from '../renderer/App.d';
 
 if (module.hot) {
   module.hot.accept();
@@ -21,6 +21,8 @@ if (module.hot) {
 declare global {
   interface Window {
     simulation: Simulation;
+    treeDepth: number;
+    serviceGraph: SGraph;
   }
 }
 

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -12,9 +12,16 @@
 import * as React from 'react';
 import { render } from 'react-dom';
 import App from './App';
+import { Simulation } from '../renderer/App.d';
 
 if (module.hot) {
   module.hot.accept();
+}
+
+declare global {
+  interface Window {
+    simulation: Simulation;
+  }
 }
 
 render(


### PR DESCRIPTION
### **PROBLEM**
On state changes, React would start a new force graph simulation. The current nodes and links would be in the old simulation and inaccessible by the javascript.

### **SOLUTION**
Hoisted simulation, serviceGraph and treeDepth to global window variables.
1. Index.tsx -- interface adds simulation, treeDepth and serviceGraph to Window as variables. Here is what the new piece of window looks like: 
```
window = {
  treeDepth: 0,
  serviceGraph: {
    links: [],
    nodes: [],
  },
  simulation: d3.forceSimulation
}
```
2. helpers/setGlobalVars.ts -- helper function to set global variables based on current services in state.
2. App.tsx -- invokes setGlobalVars function passing in services object when the state changes
3. Nodes.tsx, Links.tsx and View.tsx -- access the global variables rather than passing down vars in standard react one way data flow 