### PR TITLE
fixed vol name edge case

### DIFF
--- a/src/renderer/components/NodeVolumes.tsx
+++ b/src/renderer/components/NodeVolumes.tsx
@@ -66,7 +66,9 @@ const NodeVolumes: React.FC<Props> = ({ volumesOn, getColor }) => {
             .attr('class', 'volumeSVG')
             .attr('fill', () => {
               let slicedVString = vString.slice(0, vString.indexOf(':'));
-              return getColor(slicedVString);
+              return vString.includes(':')
+                ? getColor(slicedVString)
+                : getColor(vString);
             })
             .attr('width', width + (d.volumes.length - i) * 20)
             .attr('height', height + (d.volumes.length - i) * 20)

--- a/src/renderer/helpers/colorSchemeHash.ts
+++ b/src/renderer/helpers/colorSchemeHash.ts
@@ -10,21 +10,34 @@
 //color hash function - with passing down props
 export const colorSchemeIndex = () => {
   let currentIndex: number = 0;
-  const cachedColorObj: { [key: string]: number } = {};
+  const cachedColorObj: {
+    [key: string]: { color: number; light: number };
+  } = {};
 
   return (str: string | undefined) => {
     let currentColor: number;
+    let currentLightness: number = 60;
     if (str !== undefined && cachedColorObj[str] !== undefined) {
-      currentColor = cachedColorObj[str];
-      return `hsl(${currentColor},80%,60%)`;
+      currentColor = cachedColorObj[str].color;
+      currentLightness = cachedColorObj[str].light;
+      return `hsl(${currentColor},80%,${currentLightness}%)`;
     }
     currentColor = (40 * currentIndex + Math.floor(currentIndex / 9)) % 360;
-    currentIndex++;
-    if (str !== undefined) {
-      cachedColorObj[str] = currentColor;
+
+    if (currentIndex >= 18 && currentIndex <= 27) {
+      currentLightness = 30;
+    } else if (currentIndex >= 9) {
+      currentLightness = 80;
     }
 
-    return `hsl(${currentColor},80%,60%)`;
+    currentIndex++;
+    if (str !== undefined) {
+      cachedColorObj[str] = {
+        color: currentColor,
+        light: currentLightness,
+      };
+    }
+    return `hsl(${currentColor},80%,${currentLightness}%)`;
   };
 };
 //color hash function - w/o passing down props

--- a/src/renderer/helpers/colorSchemeHash.ts
+++ b/src/renderer/helpers/colorSchemeHash.ts
@@ -18,7 +18,7 @@ export const colorSchemeIndex = () => {
       currentColor = cachedColorObj[str];
       return `hsl(${currentColor},80%,60%)`;
     }
-    currentColor = (30 * currentIndex + Math.floor(currentIndex / 12)) % 360;
+    currentColor = (40 * currentIndex + Math.floor(currentIndex / 9)) % 360;
     currentIndex++;
     if (str !== undefined) {
       cachedColorObj[str] = currentColor;


### PR DESCRIPTION
-NodeVolumes Component: changed logic to handle volume names without a ':'
-changed color logic, after a certain number of rendered color to change lightness percentage; up to 24 diff colors, can change to whatever more colors we like.