### PR TITLE
DMG fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,14 @@
       "background": "static/background.tiff",
       "contents": [
         {
-          "x": 75,
-          "y": 300
+          "x": 100,
+          "y": 400
         },
         {
-          "x": 200,
-          "y": 300
+          "x": 550,
+          "y": 400,
+          "type": "link",
+          "path": "/Applications"
         }
       ]
     },


### PR DESCRIPTION
### **PROBLEM**
Folder to drap Nautilus App into did not work.
### **SOLUTION**
```
Changed positioning and added in type and path keys.     "dmg": {
      "background": "static/background.tiff",
      "contents": [
        {
          "x": 100,
          "y": 400
        },
        {
          "x": 550,
          "y": 400,
          "type": "link",
          "path": "/Applications"
        }
      ]
    },
```