### PR TITLE
Testing - Snapshots for App and NetworksDropdown

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import { shallow, configure, ShallowWrapper } from 'enzyme';
+import renderer from 'react-test-renderer';
+import Adapter from 'enzyme-adapter-react-16';
+import App from '../src/renderer/App';
+import fs from 'fs';
+import path from 'path';
+
+// IMPORT COMPONENTS
+import LeftNav from '../src/renderer/components/LeftNav';
+import OptionBar from '../src/renderer/components/OptionBar';
+import D3Wrapper from '../src/renderer/components/D3Wrapper';
+import { State } from '../src/renderer/App.d';
+
+configure({ adapter: new Adapter() });
+
+describe('Testing App Stateful Component', () => {
+  let wrapper: ShallowWrapper<{}, State, App>;
+  beforeEach(() => {
+    wrapper = shallow(<App />);
+  });
+
+  it('renders correctly', () => {
+    const tree = renderer.create(<App />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  describe('render()', () => {
+    it('should render child components', () => {
+      expect(wrapper.find(LeftNav)).toHaveLength(1);
+      expect(wrapper.find(OptionBar)).toHaveLength(1);
+      expect(wrapper.find(D3Wrapper)).toHaveLength(1);
+    });
+  });
+
+  describe('setSelectedContainer()', () => {
+    it('should updated selectedContainer in state', () => {
+      wrapper.instance().setSelectedContainer('tester-service');
+      expect(wrapper.state().selectedContainer).toBe('tester-service');
+      wrapper.instance().setSelectedContainer('api-service');
+      expect(wrapper.state().selectedContainer).toBe('api-service');
+    });
+  });
+
+  describe('updateView()', () => {
+    it('should update view in state', () => {
+      wrapper.instance().updateView('depends_on');
+      expect(wrapper.state().view).toBe('depends_on');
+    });
+    it('should clear selectedNetwork in state', () => {
+      wrapper.state().selectedNetwork = 'dummy-network';
+      wrapper.instance().updateView('depends_on');
+      expect(wrapper.state().selectedNetwork).toBe('');
+    });
+  });
+
+  describe('updateOption()', () => {
+    beforeEach(() => {
+      wrapper.state().options = {
+        ports: false,
+        volumes: false,
+        selectAll: false,
+      };
+    });
+    it('should toggle ports option', () => {
+      wrapper.instance().updateOption('ports');
+      expect(wrapper.state().options.ports).toBe(true);
+      wrapper.instance().updateOption('ports');
+      expect(wrapper.state().options.ports).toBe(false);
+    });
+    it('should toggle volumes option', () => {
+      wrapper.instance().updateOption('volumes');
+      expect(wrapper.state().options.volumes).toBe(true);
+      wrapper.instance().updateOption('volumes');
+      expect(wrapper.state().options.volumes).toBe(false);
+    });
+    it('should toggle selectAll option', () => {
+      wrapper.instance().updateOption('selectAll');
+      expect(wrapper.state().options.selectAll).toBe(true);
+      wrapper.instance().updateOption('selectAll');
+      expect(wrapper.state().options.selectAll).toBe(false);
+    });
+    it('selectAll should toggle ports and options', () => {
+      wrapper.instance().updateOption('selectAll');
+      expect(wrapper.state().options.ports).toBe(true);
+      expect(wrapper.state().options.volumes).toBe(true);
+      wrapper.instance().updateOption('selectAll');
+      expect(wrapper.state().options.ports).toBe(false);
+      expect(wrapper.state().options.volumes).toBe(false);
+    });
+    it('selectAll should should reflect all being selected or not', () => {
+      wrapper.instance().updateOption('ports');
+      wrapper.instance().updateOption('volumes');
+      expect(wrapper.state().options.selectAll).toBe(true);
+      wrapper.instance().updateOption('ports');
+      expect(wrapper.state().options.selectAll).toBe(false);
+    });
+  });
+
+  describe('selectNetwork()', () => {
+    it('should update view to "networks"', () => {
+      wrapper.instance().selectNetwork('dummy-network');
+      expect(wrapper.state().view).toBe('networks');
+    });
+    it('should updated selectedNetwork to passed in string', () => {
+      expect(wrapper.state().selectedNetwork).toBe('dummy-network');
+    });
+  });
+
+  describe('convertAndStoreYamlJSON()', () => {
+    let yamlText: string;
+
+    beforeAll(() => {
+      yamlText = fs
+        .readFileSync(path.resolve(__dirname, '../samples/docker-compose1.yml'))
+        .toString();
+      wrapper.instance().convertAndStoreYamlJSON(yamlText);
+    });
+
+    afterAll(() => {
+      delete window.d3State;
+      localStorage.removeItem('state');
+    });
+
+    it('should update d3State of window', () => {
+      expect(window.d3State).toBeTruthy();
+      expect(window.d3State.treeDepth).toBe(2);
+      expect(window.d3State.simulation).toBeTruthy();
+      expect(window.d3State.serviceGraph.nodes).toBeTruthy();
+      expect(window.d3State.serviceGraph.links).toBeTruthy();
+    });
+    it('should set the localstorage with item key "state"', () => {
+      expect(localStorage.getItem('state')).toBeTruthy();
+    });
+    it('should update services in state', () => {
+      const serviceNames = Object.keys(wrapper.state().services);
+      expect(serviceNames.length).toBe(5);
+      const check = serviceNames.filter(
+        n =>
+          n === 'vote' ||
+          n === 'result' ||
+          n === 'worker' ||
+          n === 'redis' ||
+          n === 'db',
+      );
+      expect(check.length).toBe(5);
+    });
+    it('should update volumes in state', () => {
+      const volumes = wrapper.state().volumes;
+      expect(volumes.hasOwnProperty('db-data')).toBe(true);
+    });
+    it('should update bindmounts in state', () => {
+      const bindMounts = wrapper.state().bindMounts;
+      expect(bindMounts.length).toBe(2);
+      const check = bindMounts.filter(n => n === './vote' || n === './result');
+      expect(check.length).toBe(2);
+    });
+    it('should update networks in state', () => {
+      const networks = Object.keys(wrapper.state().networks);
+      expect(networks.length).toBe(2);
+      const check = networks.filter(
+        n => n === 'front-tier' || n === 'back-tier',
+      );
+      expect(check.length).toBe(2);
+    });
+    it('should set fileUploaded to true', () => {
+      expect(wrapper.state().fileUploaded).toBe(true);
+    });
+  });
+
+  describe('componentDidMount()', () => {
+    let state = {
+      fileUploaded: true,
+      services: {
+        db: {
+          image: 'postgres',
+          environment: [
+            'POSTGRES_MULTIPLE_DATABASES=dpc_attribution,dpc_queue,dpc_auth,dpc_consent',
+            'POSTGRES_USER=postgres',
+            'POSTGRES_PASSWORD=dpc-safe',
+          ],
+          ports: ['5432:5432'],
+          volumes: ['./docker/postgres:/docker-entrypoint-initdb.d'],
+        },
+        aggregation: {
+          image:
+            '${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-aggregation}:latest',
+          ports: ['9901:9900'],
+          env_file: ['./ops/config/decrypted/local.env'],
+          environment: ['ENV=local', 'JACOCO=${REPORT_COVERAGE}'],
+          depends_on: ['db'],
+          volumes: [
+            'export-volume:/app/data',
+            './jacocoReport/dpc-aggregation:/jacoco-report',
+          ],
+        },
+        attribution: {
+          image:
+            '${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-attribution}:latest',
+          depends_on: ['db'],
+          environment: ['ENV=local', 'JACOCO=${REPORT_COVERAGE}'],
+          ports: ['3500:8080', '9902:9900'],
+          volumes: ['./jacocoReport/dpc-attribution:/jacoco-report'],
+        },
+        api: {
+          image:
+            '${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-api}:latest',
+          ports: ['3002:3002', '9903:9900'],
+          environment: [
+            'attributionURL=http://attribution:8080/v1/',
+            'ENV=local',
+            'JACOCO=${REPORT_COVERAGE}',
+            'exportPath=/app/data',
+            'JVM_FLAGS=-Ddpc.api.authenticationDisabled=${AUTH_DISABLED:-false}',
+          ],
+          depends_on: ['attribution'],
+          volumes: [
+            'export-volume:/app/data',
+            './jacocoReport/dpc-api:/jacoco-report',
+          ],
+        },
+        consent: {
+          image:
+            '${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-consent}:latest',
+          depends_on: ['db'],
+          environment: ['ENV=local', 'JACOCO=${REPORT_COVERAGE}'],
+          ports: ['3600:3600', '9004:9900'],
+          volumes: ['./jacocoReport/dpc-consent:/jacoco-report'],
+        },
+        start_core_dependencies: {
+          image: 'dadarek/wait-for-dependencies',
+          depends_on: ['db'],
+          command: 'db:5432',
+        },
+        start_api_dependencies: {
+          image: 'dadarek/wait-for-dependencies',
+          depends_on: ['attribution', 'aggregation'],
+          command: 'attribution:8080 aggregation:9900',
+        },
+        start_api: {
+          image: 'dadarek/wait-for-dependencies',
+          depends_on: ['api'],
+          command: 'api:3002',
+        },
+      },
+      volumes: {
+        'export-volume': {
+          driver: 'local',
+          driver_opts: { type: 'none', device: '/tmp', o: 'bind' },
+        },
+      },
+      networks: {},
+      bindMounts: [
+        './docker/postgres',
+        './jacocoReport/dpc-aggregation',
+        './jacocoReport/dpc-attribution',
+        './jacocoReport/dpc-api',
+        './jacocoReport/dpc-consent',
+      ],
+    };
+    beforeAll(() => {
+      localStorage.setItem('state', JSON.stringify(state));
+      wrapper = shallow(<App />);
+    });
+    afterAll(() => {
+      delete window.d3State;
+      localStorage.removeItem('state');
+    });
+
+    it('should set state with state from local storage', () => {
+      const appState = wrapper.state();
+      expect(appState.services).toEqual(state.services);
+      expect(appState.volumes).toEqual(state.volumes);
+      expect(appState.fileUploaded).toBe(true);
+      expect(appState.bindMounts).toEqual(state.bindMounts);
+    });
+
+    it('should set d3State on the window', () => {
+      expect(window.d3State).toBeTruthy();
+      expect(window.d3State.treeDepth).toBe(4);
+      expect(window.d3State.simulation).toBeTruthy();
+      expect(window.d3State.serviceGraph.nodes).toBeTruthy();
+      expect(window.d3State.serviceGraph.links).toBeTruthy();
+    });
+  });
+});

--- a/__tests__/NetworksDropdown.test.tsx
+++ b/__tests__/NetworksDropdown.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import NetworksDropDown from '../src/renderer/components/NetworksDropdown';
+import renderer from 'react-test-renderer';
 
 configure({ adapter: new Adapter() });
 
@@ -13,6 +14,17 @@ const props = {
 
 describe('Test Networks Dropdown Component', () => {
   // Test Select Dropdown
+  it('renders correctly', () => {
+    const snapProps = Object.assign({}, props, {
+      networks: {
+        snapTester: {},
+        dbTester: {},
+      },
+    });
+    const tree = renderer.create(<NetworksDropDown {...snapProps} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('Should render select dropdown with id of `networks`', () => {
     const wrapper = shallow(<NetworksDropDown {...props} />);
     expect(wrapper.find('select#networks')).toHaveLength(1);

--- a/__tests__/__snapshots__/App.test.tsx.snap
+++ b/__tests__/__snapshots__/App.test.tsx.snap
@@ -1,0 +1,183 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing App Stateful Component renders correctly 1`] = `
+<div
+  className="app-class"
+>
+  <div
+    className="draggable"
+  />
+  <div
+    className="left-nav"
+  >
+    <div
+      className="top-half"
+    >
+      <div
+        className="title"
+      >
+        <img
+          src="http://localhost/nautilus_logo.svg"
+        />
+        <h1>
+          Nautilus
+        </h1>
+      </div>
+    </div>
+    <div
+      className="info-dropdown"
+    >
+      <h3>
+        
+      </h3>
+      <div
+        className="content-wrapper"
+      >
+        <div
+          className="overflow-container"
+        >
+          <div
+            className="overview"
+          >
+            Please select a container with details to display.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="main flex"
+  >
+    <div
+      className="option-bar"
+    >
+      <div
+        className="views flex"
+      >
+        <select
+          className="option"
+          id="networks"
+          name="networks"
+          onChange={[Function]}
+          value=""
+        >
+          <option
+            disabled={true}
+            id="networkHeader"
+            value=""
+          >
+            networks
+          </option>
+          <option
+            className="networkOption"
+            id="groupNetworks"
+            value="groupNetworks"
+          >
+            default
+          </option>
+        </select>
+        <span
+          className="option selected"
+          id="depends_on"
+          onClick={[Function]}
+        >
+          depends on
+        </span>
+      </div>
+      <div
+        className="titles flex"
+      >
+        <h2>
+          Views
+        </h2>
+        <div
+          className="vl"
+        />
+        <h2>
+          Options
+        </h2>
+      </div>
+      <div
+        className="options flex"
+      >
+        <span
+          className="option"
+          id="ports"
+          onClick={[Function]}
+        >
+          ports
+        </span>
+        <span
+          className="option"
+          id="volumes"
+          onClick={[Function]}
+        >
+          volumes
+        </span>
+        <span
+          className="option"
+          id="selectAll"
+          onClick={[Function]}
+        >
+          select all
+        </span>
+      </div>
+    </div>
+    <div
+      className="d3-wrapper"
+    >
+      <div
+        className="error-upload-wrapper"
+      >
+        <div
+          className="file-upload"
+        >
+          <label
+            htmlFor="files"
+          >
+            <div
+              className="select-file-button upload-flex"
+            >
+              <svg
+                className="upload-button"
+                fill="currentColor"
+                height={24}
+                size={24}
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 512 512"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M296 384h-80c-13.3 0-24-10.7-24-24V192h-87.7c-17.8 0-26.7-21.5-14.1-34.1L242.3 5.7c7.5-7.5 19.8-7.5 27.3 0l152.2 152.2c12.6 12.6 3.7 34.1-14.1 34.1H320v168c0 13.3-10.7 24-24 24zm216-8v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h136v8c0 30.9 25.1 56 56 56h80c30.9 0 56-25.1 56-56v-8h136c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"
+                />
+              </svg>
+              <h5>
+                Upload
+              </h5>
+            </div>
+          </label>
+          <input
+            accept=".yml,.yaml"
+            id="files"
+            name="yaml"
+            onChange={[Function]}
+            style={
+              Object {
+                "display": "none",
+              }
+            }
+            type="file"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/__tests__/__snapshots__/NetworksDropdown.test.tsx.snap
+++ b/__tests__/__snapshots__/NetworksDropdown.test.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test Networks Dropdown Component renders correctly 1`] = `
+<select
+  className="option"
+  id="networks"
+  name="networks"
+  onChange={[Function]}
+  value=""
+>
+  <option
+    disabled={true}
+    id="networkHeader"
+    value=""
+  >
+    networks
+  </option>
+  <option
+    className="networkOption"
+    id="snapTester"
+    value="snapTester"
+  >
+    snapTester
+  </option>
+  <option
+    className="networkOption"
+    id="dbTester"
+    value="dbTester"
+  >
+    dbTester
+  </option>
+  <option
+    className="networkOption"
+    id="groupNetworks"
+    value="groupNetworks"
+  >
+    group networks
+  </option>
+</select>
+`;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "package-linux": "yarn compile && electron-builder --linux",
     "package-win": "yarn compile && electron-builder --win --x64",
     "test": "jest",
-    "test-hh": "bash ./scripts/run-test.sh"
+    "test-hh": "bash ./scripts/run-test.sh",
+    "up-snap": "jest --updateSnapshot"
   },
   "jest": {
     "setupFilesAfterEnv": [
@@ -124,6 +125,7 @@
     "@types/node": "^13.9.1",
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
+    "@types/react-test-renderer": "^16.9.2",
     "@typescript-eslint/eslint-plugin": "^2.24.0",
     "@typescript-eslint/parser": "^2.24.0",
     "babel": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "package-linux": "yarn compile && electron-builder --linux",
     "package-win": "yarn compile && electron-builder --win --x64",
     "test": "jest",
-    "test-hh": "bash ./scripts/run-test.sh",
+    "test-f": "bash ./scripts/run-test.sh",
     "up-snap": "jest --updateSnapshot"
   },
   "jest": {


### PR DESCRIPTION
### **FEATURE**
Add [snapshots](https://jestjs.io/docs/en/snapshot-testing#1-treat-snapshots-as-code) with jest. 
Add react-test-renderer.

### **USAGE**
Look at the first test in App and NetworksDropdown. Follow this pattern to write snapshot testing for the rest of the react components.
If some bug impacts the dom rendering, snapshots will catch it.
If change is intentional, run `yarn up-snap` to update snapshots.

### **THOUGHTS**
1. Do we want to take snapshots of each component? Or only one snap shot of the the whole application?
2. What do we want the state of the app to be for the snapshots?
3. TestRenderer.create() does not render our d3 components, at least as far as I was able to discern.