### PR TITLE
fixes volume-parsing of long-volume-syntax

### DIFF
--- a/src/renderer/App.d.ts
+++ b/src/renderer/App.d.ts
@@ -60,13 +60,30 @@ export type Port = {
   target: number;
 };
 
-export type Volumes = string[] | Volume[];
+export type Volumes = VolumeType[];
 
-export type Volume = {
-  type: string;
+/** Volumes may have different syntax, depending on the version
+ *
+ * https://docs.docker.com/compose/compose-file/#long-syntax-3
+ */
+type LongVolumeSyntax = Partial<{
+  type: 'volume' | 'bind' | 'tmpfs' | 'npipe';
   source: string;
   target: string;
-};
+  read_only: boolean;
+  bind: {
+    propogation: string;
+  };
+  volume: {
+    nocopy: boolean;
+  };
+  tmpft: {
+    size: number;
+  };
+  consistency: 'consistent' | 'cached' | 'delegated';
+}>;
+
+type VolumeType = string | LongVolumeSyntax;
 
 type ViewT = 'networks' | 'depends_on';
 

--- a/src/renderer/helpers/setD3State.ts
+++ b/src/renderer/helpers/setD3State.ts
@@ -14,11 +14,11 @@ import {
   TreeMap,
   Link,
   SNode,
-  Volume,
   Port,
   D3State,
   Volumes,
   Ports,
+  VolumeType,
 } from '../App.d';
 import * as d3 from 'd3';
 
@@ -65,7 +65,7 @@ interface ExtractVolumes {
 export const extractVolumes: ExtractVolumes = (volumesData) => {
   const volumes: string[] = [];
   // short syntax string
-  volumesData!.forEach((vol: string | Volume) => {
+  volumesData!.forEach((vol: VolumeType) => {
     // short syntax
     if (typeof vol === 'string') {
       volumes.push(vol);

--- a/src/renderer/helpers/yamlParser.ts
+++ b/src/renderer/helpers/yamlParser.ts
@@ -1,4 +1,4 @@
-import { ReadOnlyObj, DependsOn, Services } from '../App.d';
+import { ReadOnlyObj, DependsOn, Services, VolumeType } from '../App.d';
 
 type YamlState = {
   fileUploaded: boolean;
@@ -23,10 +23,19 @@ const convertYamlToState = (file: any) => {
     // IF SERVICE HAS VOLUMES PROPERTY
     if (services[name].volumes) {
       // iterate from all the volumes
-      services[name].volumes.forEach((volume: string): void => {
-        // if its a bind mount, capture it
-        const v = volume.split(':')[0];
-        if (!volumes.hasOwnProperty(v)) {
+      services[name].volumes.forEach((volume: VolumeType): void => {
+        let v = '';
+        if (typeof volume === 'string') {
+          // if its a bind mount, capture it
+          v = volume.split(':')[0];
+        } else if (
+          'source' in volume &&
+          volume.source &&
+          volume.type === 'bind'
+        ) {
+          v = volume.source;
+        }
+        if (!!v && !volumes.hasOwnProperty(v)) {
           bindMounts.push(v);
         }
       });


### PR DESCRIPTION
Fixes issue with parsing yaml-files using the long volume-syntax, like:

```yaml
      - type: bind
        source: ./nginx.conf.default
        target: /etc/nginx/nginx.conf
```

Previously, it would crash as it was trying to split the object as if it was a string.