### PR TITLE
Add Env File resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/github/license/oslabs-beta/nautilus?color=brown&label=license">
 
   <!-- Release -->
-  <img src="https://img.shields.io/badge/release-1.3.0-orange">
+  <img src="https://img.shields.io/badge/release-1-orange">
 
   <!-- Release Date -->
   <img src="https://img.shields.io/badge/release%20date-4%2F9%2F20-yellow">
@@ -121,9 +121,9 @@ Once you're sure you have the Docker CLI tools installed, download the Nautilus 
 
 <b>Nautilus Download Links</b>
 
-- [Mac](https://nautilusdev.com/release/Nautilus-1.3.0.dmg)
-- [Windows](https://nautilusdev.com/release/Nautilus%20Setup%201.3.0.exe)
-- [Linux](https://nautilusdev.com/release/Nautilus-1.3.0.AppImage)
+- [Mac](https://nautilusdev.com/release/Nautilus-1.3.1.dmg)
+- [Windows](https://nautilusdev.com/release/Nautilus%20Setup%201.3.1.exe)
+- [Linux](https://nautilusdev.com/release/Nautilus-1.3.1.AppImage)
 
 We are currently in the process of getting appropriate certifications/signatures so you may need to bypass some security warnings to run our application, but rest assured Nautilus does not make any network calls (and the project is 100% open source).
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/github/license/oslabs-beta/nautilus?color=brown&label=license">
 
   <!-- Release -->
-  <img src="https://img.shields.io/badge/release-1-orange">
+  <img src="https://img.shields.io/badge/release-1.3.1-orange">
 
   <!-- Release Date -->
   <img src="https://img.shields.io/badge/release%20date-4%2F9%2F20-yellow">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nautilus",
-  "version": "1.2.2",
+  "version": "1.3.1",
   "description": "A Docker Compose Charting Tool",
   "scripts": {
     "start": "cross-env NODE_ENV=production NOT_PACKAGE=true electron ./dist/main/main.js",

--- a/src/common/dockerComposeValidation.ts
+++ b/src/common/dockerComposeValidation.ts
@@ -9,7 +9,7 @@
 import child_process from 'child_process';
 import { ValidationResults } from '../renderer/App.d';
 
-const runDockerComposeValidation = (filePath: string) =>
+const dockerComposeValidation = (filePath: string) =>
   // promise for the electron application
   new Promise((resolve, reject) => {
     try {
@@ -22,15 +22,21 @@ const runDockerComposeValidation = (filePath: string) =>
           const validationResult: ValidationResults = {
             out: stdout.toString(),
             filePath,
+            envResolutionRequired: false,
           };
           // if there is an error, add the error object to validationResult obj
           if (error) {
+            //if docker-compose uses env file to run, store this variable to handle later
+            if (error.message.includes('variable is not set')) {
+              validationResult.envResolutionRequired = true;
+            }
             // filter errors we don't care about
             if (
               !error.message.includes("Couldn't find env file") &&
               !error.message.includes(
                 'either does not exist, is not accessible',
-              )
+              ) &&
+              !error.message.includes('variable is not set')
             ) {
               validationResult.error = error;
             }
@@ -42,4 +48,4 @@ const runDockerComposeValidation = (filePath: string) =>
     } catch {}
   });
 
-export default runDockerComposeValidation;
+export default dockerComposeValidation;

--- a/src/common/resolveEnvVariables.ts
+++ b/src/common/resolveEnvVariables.ts
@@ -9,7 +9,7 @@ const resolveEnvVariables = (yamlText: string, filePath: string) => {
   const envFileArray = filePath.split('/');
   const envFilePath =
     envFileArray.slice(0, envFileArray.length - 1).join('/') + '/.env';
-  //read envfile
+  //read envfile if there is one there
   let envString: string;
   try {
     envString = fs.readFileSync(envFilePath).toString();

--- a/src/common/resolveEnvVariables.ts
+++ b/src/common/resolveEnvVariables.ts
@@ -1,0 +1,42 @@
+import fs from 'fs';
+
+type EnvObject = {
+  [variableName: string]: string;
+};
+
+//this function replaces all env variables within the docker compose yaml string with their values in the env file
+const resolveEnvVariables = (yamlText: string, filePath: string) => {
+  const envFileArray = filePath.split('/');
+  const envFilePath =
+    envFileArray.slice(0, envFileArray.length - 1).join('/') + '/.env';
+  //read envfile
+  let envString: string;
+  try {
+    envString = fs.readFileSync(envFilePath).toString();
+  } catch (err) {
+    return yamlText;
+  }
+  let yamlTextCopy = yamlText;
+  console.log(envString);
+  //split by line
+  const envArray = envString.split('\n');
+  //remove empty last element
+  envArray.splice(-1, 1);
+  //create Object that stores the variable notation to be replace with its value
+  const envObject: EnvObject = envArray.reduce((acc: EnvObject, el: string) => {
+    const [variableName, value] = el.split('=');
+    const variableKey: string = '\\${' + variableName + '}';
+    acc[variableKey] = value;
+    return acc;
+  }, {});
+  //replace the variables
+  Object.keys(envObject).forEach((variableKey: string) => {
+    yamlTextCopy = yamlTextCopy.replace(
+      new RegExp(variableKey, 'g'),
+      envObject[variableKey],
+    );
+  });
+  return yamlTextCopy;
+};
+
+export default resolveEnvVariables;

--- a/src/renderer/App.d.ts
+++ b/src/renderer/App.d.ts
@@ -173,4 +173,5 @@ export type ValidationResults = {
   error?: Error;
   out: string;
   filePath: string;
+  envResolutionRequired: boolean;
 };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,12 +18,14 @@ import convertYamlToState from './helpers/yamlParser';
 import setD3State from './helpers/setD3State';
 import parseOpenError from './helpers/parseOpenError';
 import runDockerComposeValidation from '../common/dockerComposeValidation';
+import resolveEnvVariables from '../common/resolveEnvVariables';
 
 // IMPORT REACT CONTAINERS OR COMPONENTS
 import LeftNav from './components/LeftNav';
 import OptionBar from './components/OptionBar';
 import D3Wrapper from './components/D3Wrapper';
 
+//IMPORT TYPES
 import {
   State,
   FileOpen,
@@ -133,7 +135,12 @@ class App extends Component<{}, State> {
           fileReader.onload = () => {
             // if successful read, invoke method to convert and store to state
             if (fileReader.result) {
-              this.convertAndStoreYamlJSON(fileReader.result.toString());
+              let yamlText = fileReader.result.toString();
+              //if docker-compose uses env file, replace the variables with value from env file
+              if (validationResults.envResolutionRequired) {
+                yamlText = resolveEnvVariables(yamlText, file.path);
+              }
+              this.convertAndStoreYamlJSON(yamlText);
             }
           };
           // read the file


### PR DESCRIPTION
Closes #169 

Add Env file resolution when a .env file is stored in the same folder as the docker compose file.

If there is no .env file stored in the same folder, then the ${variablename}  notation will resume

